### PR TITLE
detect if // or /* describe a pixel

### DIFF
--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -13,6 +13,9 @@ static bool line_is_comment(char *line) {
 
 	// Remove comments from line
 	char *multiline_start = NULL;
+	char *first_quote;
+	char *second_quote;
+
 	do {
 		if (is_multiline) {
 			char *multiline_end;
@@ -29,11 +32,26 @@ static bool line_is_comment(char *line) {
 			multiline_end += strlen("*/");
 			memmove(multiline_start, multiline_end, strlen(multiline_end) + 1);
 		}
+
+		first_quote = strstr(line, "\"");
 		char *singleline_start = strstr(line, "//");
+		if (first_quote)
+		{
+			second_quote = strstr(first_quote + 1, "\"");
+			if (first_quote < singleline_start && multiline_start < second_quote)
+				singleline_start = NULL;
+		}
 		if (singleline_start)
 			*singleline_start = '\0';
 
+		first_quote = strstr(line, "\"");
 		multiline_start = strstr(line, "/*");
+		if (first_quote)
+		{
+			second_quote = strstr(first_quote + 1, "\"");
+			if (first_quote < multiline_start && multiline_start < second_quote)
+				multiline_start = NULL;
+		}
 	} while (multiline_start && (multiline_num = line_number, is_multiline = true));
 
 	// Return true if the line is only whitespace at this point


### PR DESCRIPTION
# Adding support for `//` and `/*` in color descriptors
This pull request aims to allow the use of the sequence of characters `//` and `/*` in color descriptors.
The bug was found when trying to visualise the following file in its `XPM` format, which contains 25802 colors:

![accordeon](https://github.com/user-attachments/assets/6e39d037-ce96-4d5d-81a9-c65732bb16cd)

## Description of the problem
A few colors contained `//` or `/*` in their descriptor, which triggered an error in line 103 of `src/parser.c`. The length of the buffer returned by `get_next_line_check_eof()` at line 99 was smaller for lines containing `//` or `/*` in quotes, when in reality, these should have been ignored. The reason why the buffer was smaller is because the function `line_is_comment()` in `src/tokenizer.c` was setting `multiline_start` or `singleline_start` to a non-NULL value when `//` or `/*` were found, even if these sequence of characters were inside the quotes.

## Proposed solution
A very simple solution is proposed: look for the character `"`, if it is found then look for a second `"` via the function `strstr()` (note that `strchr()` would also work). Then, if the address of `multiline_start` is inbetween the addresses of the two quotes, we set `multiline_start` to NULL since it was a false positive. The exact same logic is applied to `singleline_start`.